### PR TITLE
Update vendor definition of a plugin

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.intellij.lang.typeql</id>
     <name>TypeQL</name>
-    <vendor email="community@vaticle.com" url="https://vaticle.com">Vaticle</vendor>
+    <vendor email="community@typedb.org" url="https://typedb.org">typedb-osi</vendor>
 
     <depends>com.intellij.modules.lang</depends>
 


### PR DESCRIPTION
# What is the goal of this PR?

Move the plugin to be published under [TypeDB OSI organisation](https://plugins.jetbrains.com/organizations/typedb-osi) of JetBrains Marketplace

# What are the changes implemented in this PR?

Update `<vendor>` definition to match organization ID